### PR TITLE
Put waiting tasks into queue instead of goroutines

### DIFF
--- a/pacer/pacer.go
+++ b/pacer/pacer.go
@@ -14,14 +14,15 @@ package pacer
 import "time"
 
 // Pacer is a goroutine rate limiter.  When concurrent goroutines call
-// Pacer.Next(), the call returns in one goroutine at a time, at a rate no
+// Pacer.Next(), the call returns in a single goroutine at a time, at a rate no
 // faster than one per delay time.
 //
 // To use Pacer, create a new Pacer giving the interval that must elapse
 // between the start of one task the start of the next task.  Then call Pace(),
 // passing your task function.  A new paced task function is returned that can
 // then be passed to WorkerPool's Submit() or SubmitWait(), or called as a go
-// routine.  Paced functions run as goroutines, are also paced.  For example:
+// routine.  Paced functions, that are run as goroutines, are also paced.  For
+// example:
 //
 //     pacer := pacer.NewPacer(time.Second)
 //

--- a/workerpool.go
+++ b/workerpool.go
@@ -130,7 +130,7 @@ Loop:
 		// As long as tasks are in the waiting queue, remove and execute these
 		// tasks as workers become available, and place new incoming tasks on
 		// the queue.  Once the queue is empty, then go back to submitting
-		// incocoming tasks directly to available workers.
+		// incoming tasks directly to available workers.
 		if p.waitingQueue.Len() != 0 {
 			select {
 			case task, ok = <-p.taskQueue:

--- a/workerpool.go
+++ b/workerpool.go
@@ -1,6 +1,10 @@
 package workerpool
 
-import "time"
+import (
+	"time"
+
+	"github.com/gammazero/deque"
+)
 
 const (
 	// This value is the size of the queue that workers register their
@@ -26,7 +30,7 @@ func New(maxWorkers int) *WorkerPool {
 
 	// taskQueue is unbuffered since items are always removed immediately.
 	pool := &WorkerPool{
-		taskQueue:    make(chan func()),
+		taskQueue:    make(chan func(), 1),
 		maxWorkers:   maxWorkers,
 		readyWorkers: make(chan chan func(), readyQueueSize),
 		timeout:      time.Second * idleTimeoutSec,
@@ -47,6 +51,7 @@ type WorkerPool struct {
 	taskQueue    chan func()
 	readyWorkers chan chan func()
 	stoppedChan  chan struct{}
+	waitingQueue deque.Deque
 }
 
 // Stop stops the worker pool and waits for workers to complete.
@@ -83,6 +88,16 @@ func (p *WorkerPool) Stopped() bool {
 // be given to the next available worker.  If there are no available workers,
 // the dispatcher adds a worker, until the maximum number of workers is
 // running.
+//
+// After the maximum number of workers are running, and no workers are
+// available, incoming tasks are put onto a queue and will be executed as
+// workers become available.
+//
+// When no new tasks have been submitted for time period and a worker is
+// available, the worker is shutdown.  As long as no new tasks arrive, one
+// available worker is shutdown each time period until there are no more idle
+// workers.  Since the time to start new goroutines is not significant, there
+// is no need to retain idle workers.
 func (p *WorkerPool) Submit(task func()) {
 	if task != nil {
 		p.taskQueue <- task
@@ -113,6 +128,23 @@ func (p *WorkerPool) dispatch() {
 	startReady := make(chan chan func())
 Loop:
 	for {
+		// As long as tasks are in the waiting queue, remove and execute these
+		// tasks as workers become available, and place new incoming tasks on
+		// the queue.  Once the queue is empty, then go back to submitting
+		// incocoming tasks directly to available workers.
+		if p.waitingQueue.Len() != 0 {
+			select {
+			case task, ok = <-p.taskQueue:
+				if !ok {
+					break Loop
+				}
+				p.waitingQueue.PushBack(task)
+			case workerTaskChan = <-p.readyWorkers:
+				// A worker is ready, so give task to worker.
+				workerTaskChan <- p.waitingQueue.PopFront().(func())
+			}
+			continue
+		}
 		timeout.Reset(p.timeout)
 		select {
 		case task, ok = <-p.taskQueue:
@@ -136,12 +168,8 @@ Loop:
 						taskChan <- t
 					}(task)
 				} else {
-					// Start a goroutine to submit the task when an existing
-					// worker is ready.
-					go func(t func()) {
-						taskChan := <-p.readyWorkers
-						taskChan <- t
-					}(task)
+					// Enqueue the task to be executed by next available worker.
+					p.waitingQueue.PushBack(task)
 				}
 			}
 		case <-timeout.C:

--- a/workerpool.go
+++ b/workerpool.go
@@ -28,7 +28,6 @@ func New(maxWorkers int) *WorkerPool {
 		maxWorkers = 1
 	}
 
-	// taskQueue is unbuffered since items are always removed immediately.
 	pool := &WorkerPool{
 		taskQueue:    make(chan func(), 1),
 		maxWorkers:   maxWorkers,

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -236,6 +236,25 @@ func BenchmarkEnqueue(b *testing.B) {
 	close(releaseChan)
 }
 
+func BenchmarkEnqueue2(b *testing.B) {
+	wp := New(2)
+	defer wp.Stop()
+	releaseChan := make(chan struct{})
+
+	b.ResetTimer()
+
+	// Start workers, and have them all wait on a channel before completing.
+	for i := 0; i < b.N; i++ {
+		for i := 0; i < 64; i++ {
+			wp.Submit(func() { <-releaseChan })
+		}
+		for i := 0; i < 64; i++ {
+			releaseChan <- struct{}{}
+		}
+	}
+	close(releaseChan)
+}
+
 func BenchmarkExecute1Worker(b *testing.B) {
 	wp := New(1)
 	defer wp.Stop()

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -30,7 +30,7 @@ func TestMaxWorkers(t *testing.T) {
 		})
 	}
 
-	// Wait for all enqueued tasks to be dispatched to workers.
+	// Wait for all queued tasks to be dispatched to workers.
 	timeout := time.After(5 * time.Second)
 	for startCount := 0; startCount < max; {
 		select {
@@ -90,7 +90,7 @@ func TestWorkerTimeout(t *testing.T) {
 	}
 
 	if anyReady(wp) {
-		t.Fatal("number of ready workers should ber zero")
+		t.Fatal("number of ready workers should be zero")
 	}
 	// Release workers.
 	close(sync)
@@ -129,7 +129,7 @@ func TestStop(t *testing.T) {
 		})
 	}
 
-	// Wait for all enqueued tasks to be dispatched to workers.
+	// Wait for all queued tasks to be dispatched to workers.
 	timeout := time.After(5 * time.Second)
 	for startCount := 0; startCount < max; {
 		select {
@@ -183,8 +183,6 @@ func TestSubmitWait(t *testing.T) {
 func TestOverflow(t *testing.T) {
 	wp := New(2)
 	releaseChan := make(chan struct{})
-
-	//lastDone := make(chan struct{})
 
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < 64; i++ {


### PR DESCRIPTION
When the maximum number of workers are all in use, this results in:
- faster task queuing
- lower memory use 

The memory savings can be significant where a very large number of tasks, beyond the maximum number of workers, are waiting.