### PR TITLE
An extremely simple method to return queue sizes

### DIFF
--- a/workerpool.go
+++ b/workerpool.go
@@ -274,13 +274,3 @@ func (p *WorkerPool) stop(wait bool) {
 func (p *WorkerPool) WaitingQueueSize() int {
 	return p.waitingQueue.Len()
 }
-
-// TaksQueueSize will return the size of task queue
-func (p *WorkerPool) TaksQueueSize() int {
-	return len(p.taskQueue)
-}
-
-// QueueSize will return the size of the task queue first and waiting queue second
-func (p *WorkerPool) QueueSize() (int, int) {
-	return len(p.taskQueue), p.waitingQueue.Len()
-}

--- a/workerpool.go
+++ b/workerpool.go
@@ -269,3 +269,18 @@ func (p *WorkerPool) stop(wait bool) {
 	close(p.taskQueue)
 	<-p.stoppedChan
 }
+
+// WaitingQueueSize will return the size of the waiting queue
+func (p *WorkerPool) WaitingQueueSize() int {
+	return p.waitingQueue.Len()
+}
+
+// TaksQueueSize will return the size of task queue
+func (p *WorkerPool) TaksQueueSize() int {
+	return len(p.taskQueue)
+}
+
+// QueueSize will return the size of the task queue first and waiting queue second
+func (p *WorkerPool) QueueSize() (int, int) {
+	return len(p.taskQueue), p.waitingQueue.Len()
+}

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -61,6 +61,14 @@ func TestMaxWorkers(t *testing.T) {
 
 	// Wait for all queued tasks to be dispatched to workers.
 	timeout := time.After(5 * time.Second)
+	taskq, wq := wp.QueueSize()
+	if taskq != wp.TaksQueueSize() {
+		t.Fatal("Internal task queue and produced task queue has different length")
+	}
+	if wq != wp.WaitingQueueSize() {
+		t.Fatal("Working Queue size returned should not be 0")
+		panic("WRONG")
+	}
 	for startCount := 0; startCount < max; {
 		select {
 		case <-started:

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -61,11 +61,7 @@ func TestMaxWorkers(t *testing.T) {
 
 	// Wait for all queued tasks to be dispatched to workers.
 	timeout := time.After(5 * time.Second)
-	taskq, wq := wp.QueueSize()
-	if taskq != wp.TaksQueueSize() {
-		t.Fatal("Internal task queue and produced task queue has different length")
-	}
-	if wq != wp.WaitingQueueSize() {
+	if wp.waitingQueue.Len() != wp.WaitingQueueSize() {
 		t.Fatal("Working Queue size returned should not be 0")
 		panic("WRONG")
 	}


### PR DESCRIPTION
As monitoring is rather important in most cases I was missing some simple methods to query the size of the queues to send them to Prometheus. This is an extremely clean and simple solution, doesn't really impact anything beyond queue size returned...