### PR TITLE
Adding testcase for concurrent use of WaitingQueueSize()

### DIFF
--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -365,6 +365,10 @@ func TestWaitingQueueSizeRace(t *testing.T) {
 				continue
 			}
 			wp.Submit(func() { <-workRelChan })
+			// Wait for task to be removed from task queue.
+			for len(wp.taskQueue) != 0 {
+				time.Sleep(time.Microsecond)
+			}
 		}
 		close(errChan)
 	}()


### PR DESCRIPTION
This adds a test for concurrent usage of `WaitingQueueSize()`.
This currently will fail if run with the go race detector `go test -race` because the underlying deque used for the queue of waiting tasks is *not* thread-safe.