### PR TITLE
Use fewer channels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/gammazero/workerpool
 
-require github.com/gammazero/deque v0.0.0-20200124200322-7e84b94275b8
+require github.com/gammazero/deque v0.0.0-20200227231300-1e9af0e52b46
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622 h1:lxbhOGZ9pU3Kf8P
 github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622/go.mod h1:D90+MBHVc9Sk1lJAbEVgws0eYEurY4mv2TDso3Nxh3w=
 github.com/gammazero/deque v0.0.0-20200124200322-7e84b94275b8 h1:9eg1l6iiw3aLaU3P8RRoosiYCRoWDg8HzPiy8xzWKgg=
 github.com/gammazero/deque v0.0.0-20200124200322-7e84b94275b8/go.mod h1:D90+MBHVc9Sk1lJAbEVgws0eYEurY4mv2TDso3Nxh3w=
+github.com/gammazero/deque v0.0.0-20200227231300-1e9af0e52b46 h1:iX4+rD9Fjdx8SkmSO/O5WAIX/j79ll3kuqv5VdYt9J8=
+github.com/gammazero/deque v0.0.0-20200227231300-1e9af0e52b46/go.mod h1:D90+MBHVc9Sk1lJAbEVgws0eYEurY4mv2TDso3Nxh3w=

--- a/workerpool.go
+++ b/workerpool.go
@@ -8,11 +8,6 @@ import (
 )
 
 const (
-	// This value is the size of the queue that workers register their
-	// availability to the dispatcher.  There may be hundreds of workers, but
-	// only a small channel is needed to register some of the workers.
-	readyQueueSize = 16
-
 	// If worker pool receives no new work for this period of time, then stop
 	// a worker goroutine.
 	idleTimeoutSec = 5
@@ -30,11 +25,11 @@ func New(maxWorkers int) *WorkerPool {
 	}
 
 	pool := &WorkerPool{
-		taskQueue:    make(chan func(), 1),
-		maxWorkers:   maxWorkers,
-		readyWorkers: make(chan chan func(), readyQueueSize),
-		timeout:      time.Second * idleTimeoutSec,
-		stoppedChan:  make(chan struct{}),
+		maxWorkers:  maxWorkers,
+		timeout:     time.Second * idleTimeoutSec,
+		taskQueue:   make(chan func(), 1),
+		workerQueue: make(chan func()),
+		stoppedChan: make(chan struct{}),
 	}
 
 	// Start the task dispatcher.
@@ -49,7 +44,7 @@ type WorkerPool struct {
 	maxWorkers   int
 	timeout      time.Duration
 	taskQueue    chan func()
-	readyWorkers chan chan func()
+	workerQueue  chan func()
 	stoppedChan  chan struct{}
 	waitingQueue deque.Deque
 	stopOnce     sync.Once
@@ -130,12 +125,10 @@ func (p *WorkerPool) dispatch() {
 	defer close(p.stoppedChan)
 	timeout := time.NewTimer(p.timeout)
 	var (
-		workerCount    int
-		task           func()
-		ok, wait       bool
-		workerTaskChan chan func()
+		workerCount int
+		task        func()
+		ok, wait    bool
 	)
-	startReady := make(chan chan func())
 Loop:
 	for {
 		// As long as tasks are in the waiting queue, remove and execute these
@@ -153,9 +146,9 @@ Loop:
 					break Loop
 				}
 				p.waitingQueue.PushBack(task)
-			case workerTaskChan = <-p.readyWorkers:
-				// A worker is ready, so give task to worker.
-				workerTaskChan <- p.waitingQueue.PopFront().(func())
+			case p.workerQueue <- p.waitingQueue.Front().(func()):
+				// A worker was ready, so gave task to worker.
+				p.waitingQueue.PopFront()
 			}
 			atomic.StoreInt32(&p.waiting, int32(p.waitingQueue.Len()))
 			continue
@@ -168,19 +161,16 @@ Loop:
 			}
 			// Got a task to do.
 			select {
-			case workerTaskChan = <-p.readyWorkers:
-				// A worker is ready, so give task to worker.
-				workerTaskChan <- task
+			case p.workerQueue <- task:
 			default:
 				// No workers ready.
 				// Create a new worker, if not at max.
 				if workerCount < p.maxWorkers {
 					workerCount++
 					go func(t func()) {
-						startWorker(startReady, p.readyWorkers)
-						// Submit the task when the new worker.
-						taskChan := <-startReady
-						taskChan <- t
+						// Run initial task and start worker waiting for more.
+						t()
+						go startWorker(p.workerQueue)
 					}(task)
 				} else {
 					// Enqueue task to be executed by next available worker.
@@ -192,9 +182,8 @@ Loop:
 			// Timed out waiting for work to arrive.  Kill a ready worker.
 			if workerCount > 0 {
 				select {
-				case workerTaskChan = <-p.readyWorkers:
-					// A worker is ready, so kill.
-					close(workerTaskChan)
+				case p.workerQueue <- nil:
+					// Send kill signal to worker.
 					workerCount--
 				default:
 					// No work, but no ready workers.  All workers are busy.
@@ -207,51 +196,30 @@ Loop:
 	// give to workers until queue is empty.
 	if wait {
 		for p.waitingQueue.Len() != 0 {
-			workerTaskChan = <-p.readyWorkers
 			// A worker is ready, so give task to worker.
-			workerTaskChan <- p.waitingQueue.PopFront().(func())
+			p.workerQueue <- p.waitingQueue.PopFront().(func())
 			atomic.StoreInt32(&p.waiting, int32(p.waitingQueue.Len()))
 		}
 	}
 
 	// Stop all remaining workers as they become ready.
 	for workerCount > 0 {
-		workerTaskChan = <-p.readyWorkers
-		close(workerTaskChan)
+		p.workerQueue <- nil
 		workerCount--
 	}
 }
 
 // startWorker starts a goroutine that executes tasks given by the dispatcher.
 //
-// When a new worker starts, it registers its availability on the startReady
-// channel.  This ensures that the goroutine associated with starting the
-// worker gets to use the worker to execute its task.  Otherwise, the main
-// dispatcher loop could steal the new worker and not know to start up another
-// worker for the waiting goroutine.  The task would then have to wait for
-// another existing worker to become available, even though capacity is
-// available to start additional workers.
-//
-// A worker registers that is it available to do work by putting its task
-// channel on the readyWorkers channel.  The dispatcher reads a worker's task
-// channel from the readyWorkers channel, and writes a task to the worker over
-// the worker's task channel.  To stop a worker, the dispatcher closes a
-// worker's task channel, instead of writing a task to it.
-func startWorker(startReady, readyWorkers chan chan func()) {
-	go func() {
-		taskChan := make(chan func())
-		var task func()
-		// Register availability on starReady channel.
-		startReady <- taskChan
-		// Read tasks from dispatcher.
-		for task = range taskChan {
-			// Execute the task.
-			task()
-
-			// Register availability on readyWorkers channel.
-			readyWorkers <- taskChan
+// To stop a worker, the dispatcher writes nil to the worker task queue.
+func startWorker(workerQueue chan func()) {
+	// Read tasks from dispatcher and execute.
+	for task := range workerQueue {
+		if task == nil {
+			return
 		}
-	}()
+		task()
+	}
 }
 
 // stop tells the dispatcher to exit, and whether or not to complete queued

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -63,7 +63,6 @@ func TestMaxWorkers(t *testing.T) {
 	timeout := time.After(5 * time.Second)
 	if wp.waitingQueue.Len() != wp.WaitingQueueSize() {
 		t.Fatal("Working Queue size returned should not be 0")
-		panic("WRONG")
 	}
 	for startCount := 0; startCount < max; {
 		select {

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -475,7 +475,6 @@ func BenchmarkExecute1Worker(b *testing.B) {
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < b.N; i++ {
 		wp.Submit(func() {
-			time.Sleep(time.Millisecond)
 			allDone.Done()
 		})
 	}
@@ -493,7 +492,6 @@ func BenchmarkExecute2Worker(b *testing.B) {
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < b.N; i++ {
 		wp.Submit(func() {
-			time.Sleep(time.Millisecond)
 			allDone.Done()
 		})
 	}
@@ -511,7 +509,6 @@ func BenchmarkExecute4Workers(b *testing.B) {
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < b.N; i++ {
 		wp.Submit(func() {
-			time.Sleep(time.Millisecond)
 			allDone.Done()
 		})
 	}
@@ -529,7 +526,6 @@ func BenchmarkExecute16Workers(b *testing.B) {
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < b.N; i++ {
 		wp.Submit(func() {
-			time.Sleep(time.Millisecond)
 			allDone.Done()
 		})
 	}
@@ -547,7 +543,6 @@ func BenchmarkExecute64Workers(b *testing.B) {
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < b.N; i++ {
 		wp.Submit(func() {
-			time.Sleep(time.Millisecond)
 			allDone.Done()
 		})
 	}


### PR DESCRIPTION
- When starting a new worker, run initial task immediately instead of using separate start channel.
- Workers all read tasks from one channel, instead of providing their own channel to the dispatcher.
