### PR TITLE
Minor performance enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+coverage.out

--- a/doc.go
+++ b/doc.go
@@ -10,12 +10,10 @@ Non-blocking task submission
 
 A task is a function submitted to the worker pool for execution.  Submitting
 tasks to this worker pool will not block, regardless of the number of tasks.
-Tasks read from the input task queue are immediately dispatched to an available
+Incoming tasks are immediately dispatched to an available
 worker.  If no worker is immediately available, or there are already tasks
 waiting for an available worker, then the task is put on a waiting queue to
-wait for an available worker.  This clears the incoming task from the input
-task queue immediately, whether or not a worker is currently available, and
-will not block the submission of tasks.
+wait for an available worker.
 
 The intent of the worker pool is to limit the concurrency of task execution,
 not limit the number of tasks queued to be executed.  Therefore, this unbounded
@@ -29,7 +27,7 @@ message queue, etc.
 Dispatcher
 
 This worker pool uses a single dispatcher goroutine to read tasks from the
-input task queue and dispatch them to a worker goroutine.  This allows for a
+input task queue and dispatch them to worker goroutines.  This allows for a
 small input channel, and lets the dispatcher queue as many tasks as are
 submitted when there are no available workers.  Additionally, the dispatcher
 can adjust the number of workers as appropriate for the work load, without
@@ -50,10 +48,12 @@ than tasks that use Y Mb of memory.
 Waiting queue vs goroutines
 
 When there are no available workers to handle incoming tasks, the tasks are put
-on a waiting queue.  In previous versions of workerpool, these tasks were
-passed to goroutines.  Using a queue is faster and has less memory overhead
-than creating a separate goroutine for each waiting task, allowing a much
-higher number of waiting tasks.
+on a waiting queue, in this implementation.  In implementations mentioned in
+the credits below, these tasks were passed to goroutines.  Using a queue is
+faster and has less memory overhead than creating a separate goroutine for each
+waiting task, allowing a much higher number of waiting tasks.  Also, using a
+waiting queue ensures that tasks are given to workers in the order the tasks
+were received.
 
 Credits
 

--- a/workerpool.go
+++ b/workerpool.go
@@ -185,9 +185,11 @@ Loop:
 		p.workerQueue <- nil
 		workerCount--
 	}
+
+	timeout.Stop()
 }
 
-// startWorker runs initial task and start worker waiting for more.
+// startWorker runs initial task, then starts a worker waiting for more.
 func startWorker(task func(), workerQueue chan func()) {
 	task()
 	go worker(workerQueue)

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -142,9 +142,15 @@ func TestWorkerTimeout(t *testing.T) {
 	}
 
 	// Check that a worker timed out.
-	time.Sleep(idleTimeout + time.Second)
+	time.Sleep(idleTimeout*2 + idleTimeout/2)
 	if countReady(wp) != max-1 {
 		t.Fatal("First worker did not timeout")
+	}
+
+	// Check that another worker timed out.
+	time.Sleep(idleTimeout)
+	if countReady(wp) != max-2 {
+		t.Fatal("Second worker did not timeout")
 	}
 }
 
@@ -425,7 +431,7 @@ func anyReady(w *WorkerPool) bool {
 
 func countReady(w *WorkerPool) int {
 	// Try to stop max workers.
-	timeout := time.After(time.Second)
+	timeout := time.After(100 * time.Millisecond)
 	var readyCount int
 	for i := 0; i < max; i++ {
 		select {

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -53,21 +53,21 @@ func TestMaxWorkers(t *testing.T) {
 	}
 
 	started := make(chan struct{}, max)
-	sync := make(chan struct{})
+	release := make(chan struct{})
 
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < max; i++ {
 		wp.Submit(func() {
 			started <- struct{}{}
-			<-sync
+			<-release
 		})
 	}
 
 	// Wait for all queued tasks to be dispatched to workers.
-	timeout := time.After(5 * time.Second)
 	if wp.waitingQueue.Len() != wp.WaitingQueueSize() {
 		t.Fatal("Working Queue size returned should not be 0")
 	}
+	timeout := time.After(5 * time.Second)
 	for startCount := 0; startCount < max; {
 		select {
 		case <-started:
@@ -78,7 +78,7 @@ func TestMaxWorkers(t *testing.T) {
 	}
 
 	// Release workers.
-	close(sync)
+	close(release)
 }
 
 func TestReuseWorkers(t *testing.T) {
@@ -87,14 +87,15 @@ func TestReuseWorkers(t *testing.T) {
 	wp := New(5)
 	defer wp.Stop()
 
-	sync := make(chan struct{})
+	release := make(chan struct{})
 
 	// Cause worker to be created, and available for reuse before next task.
 	for i := 0; i < 10; i++ {
-		wp.Submit(func() { <-sync })
-		sync <- struct{}{}
-		time.Sleep(100 * time.Millisecond)
+		wp.Submit(func() { <-release })
+		release <- struct{}{}
+		time.Sleep(time.Millisecond)
 	}
+	close(release)
 
 	// If the same worker was always reused, then only one worker would have
 	// been created and there should only be one ready.
@@ -109,42 +110,41 @@ func TestWorkerTimeout(t *testing.T) {
 	wp := New(max)
 	defer wp.Stop()
 
-	sync := make(chan struct{})
-	started := make(chan struct{}, max)
+	var started sync.WaitGroup
+	started.Add(max)
+	release := make(chan struct{})
+
 	// Cause workers to be created.  Workers wait on channel, keeping them busy
 	// and causing the worker pool to create more.
 	for i := 0; i < max; i++ {
 		wp.Submit(func() {
-			started <- struct{}{}
-			<-sync
+			started.Done()
+			<-release
 		})
 	}
 
 	// Wait for tasks to start.
-	for i := 0; i < max; i++ {
-		<-started
-	}
+	started.Wait()
 
 	if anyReady(wp) {
 		t.Fatal("number of ready workers should be zero")
 	}
+
+	if wp.killIdleWorker() {
+		t.Fatal("should have been no idle workers to kill")
+	}
+
 	// Release workers.
-	close(sync)
+	close(release)
 
 	if countReady(wp) != max {
 		t.Fatal("Expected", max, "ready workers")
 	}
 
 	// Check that a worker timed out.
-	time.Sleep((idleTimeoutSec + 1) * time.Second)
+	time.Sleep(idleTimeout + time.Second)
 	if countReady(wp) != max-1 {
 		t.Fatal("First worker did not timeout")
-	}
-
-	// Check that another worker timed out.
-	time.Sleep((idleTimeoutSec + 1) * time.Second)
-	if countReady(wp) != max-2 {
-		t.Fatal("Second worker did not timeout")
 	}
 }
 
@@ -154,30 +154,23 @@ func TestStop(t *testing.T) {
 	wp := New(max)
 	defer wp.Stop()
 
-	started := make(chan struct{}, max)
-	sync := make(chan struct{})
+	release := make(chan struct{})
+	var started sync.WaitGroup
+	started.Add(max)
 
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < max; i++ {
 		wp.Submit(func() {
-			started <- struct{}{}
-			<-sync
+			started.Done()
+			<-release
 		})
 	}
 
 	// Wait for all queued tasks to be dispatched to workers.
-	timeout := time.After(5 * time.Second)
-	for startCount := 0; startCount < max; {
-		select {
-		case <-started:
-			startCount++
-		case <-timeout:
-			t.Fatal("timed out waiting for workers to start")
-		}
-	}
+	started.Wait()
 
 	// Release workers.
-	close(sync)
+	close(release)
 
 	if wp.Stopped() {
 		t.Fatal("pool should not be stopped")
@@ -194,19 +187,19 @@ func TestStop(t *testing.T) {
 
 	// Start workers, and have them all wait on a channel before completing.
 	wp = New(5)
-	sync = make(chan struct{})
+	release = make(chan struct{})
 	finished := make(chan struct{}, max)
 	for i := 0; i < max; i++ {
 		wp.Submit(func() {
-			<-sync
+			<-release
 			finished <- struct{}{}
 		})
 	}
 
 	// Call Stop() and see that only the already running tasks were completed.
 	go func() {
-		time.Sleep(10000 * time.Millisecond)
-		close(sync)
+		time.Sleep(10 * time.Millisecond)
+		close(release)
 	}()
 	wp.Stop()
 	var count int
@@ -232,11 +225,11 @@ func TestStopWait(t *testing.T) {
 
 	// Start workers, and have them all wait on a channel before completing.
 	wp := New(5)
-	sync := make(chan struct{})
+	release := make(chan struct{})
 	finished := make(chan struct{}, max)
 	for i := 0; i < max; i++ {
 		wp.Submit(func() {
-			<-sync
+			<-release
 			finished <- struct{}{}
 		})
 	}
@@ -244,7 +237,7 @@ func TestStopWait(t *testing.T) {
 	// Call StopWait() and see that all tasks were completed.
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		close(sync)
+		close(release)
 	}()
 	wp.StopWait()
 	for count := 0; count < max; count++ {
@@ -334,24 +327,46 @@ func TestOverflow(t *testing.T) {
 
 func TestStopRace(t *testing.T) {
 	wp := New(20)
-	releaseChan := make(chan struct{})
 	workRelChan := make(chan struct{})
+
+	var started sync.WaitGroup
+	started.Add(20)
 
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < 20; i++ {
-		wp.Submit(func() { <-workRelChan })
+		wp.Submit(func() {
+			started.Done()
+			<-workRelChan
+		})
 	}
 
-	time.Sleep(5 * time.Second)
-	for i := 0; i < 64; i++ {
+	started.Wait()
+
+	const doneCallers = 5
+	stopDone := make(chan struct{}, doneCallers)
+	for i := 0; i < doneCallers; i++ {
 		go func() {
-			<-releaseChan
 			wp.Stop()
+			stopDone <- struct{}{}
 		}()
 	}
 
+	select {
+	case <-stopDone:
+		t.Fatal("Stop should not return in any goroutine")
+	default:
+	}
+
 	close(workRelChan)
-	close(releaseChan)
+
+	timeout := time.After(time.Second)
+	for i := 0; i < doneCallers; i++ {
+		select {
+		case <-stopDone:
+		case <-timeout:
+			t.Fatal("timedout waiting for Stop to return")
+		}
+	}
 }
 
 // Run this test with race detector to test that using WaitingQueueSize has no
@@ -382,7 +397,7 @@ func TestWaitingQueueSizeRace(t *testing.T) {
 		}()
 	}
 
-	// Find maximum queuesize seen by any thread.
+	// Find maximum queuesize seen by any goroutine.
 	maxMax := 0
 	for g := 0; g < goroutines; g++ {
 		max := <-maxChan
@@ -401,7 +416,7 @@ func TestWaitingQueueSizeRace(t *testing.T) {
 func anyReady(w *WorkerPool) bool {
 	select {
 	case w.workerQueue <- nil:
-		go startWorker(w.workerQueue)
+		go worker(w.workerQueue)
 		return true
 	default:
 	}
@@ -410,21 +425,20 @@ func anyReady(w *WorkerPool) bool {
 
 func countReady(w *WorkerPool) int {
 	// Try to stop max workers.
-	timeout := time.After(5 * time.Second)
+	timeout := time.After(time.Second)
 	var readyCount int
 	for i := 0; i < max; i++ {
 		select {
 		case w.workerQueue <- nil:
 			readyCount++
 		case <-timeout:
-			readyCount = i
 			i = max
 		}
 	}
 
 	// Restore workers.
 	for i := 0; i < readyCount; i++ {
-		go startWorker(w.workerQueue)
+		go worker(w.workerQueue)
 	}
 	return readyCount
 }


### PR DESCRIPTION
- Do not reset idle timer after every task
- Idle timer timeout should be const, not member var
- All callers of Stop and StopWait will wait for WorkerPool to stop
- Faster test execution
- Function decomposition for readability