### PR TITLE
Make pause behavior safe with stopping and concurrency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.13.x
   - 1.14.x
+  - 1.15.x
   - tip
 
 before_script:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/gammazero/workerpool
 
-require github.com/gammazero/deque v0.0.0-20200227231300-1e9af0e52b46
+require github.com/gammazero/deque v0.0.0-20200721202602-07291166fe33
 
-go 1.13
+go 1.14

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,2 @@
-github.com/gammazero/deque v0.0.0-20190515085511-50f5fc498a27 h1:eqgrF1fSzfhRQet8I3ws3MrGPLS7z2n1emuetE3yr2w=
-github.com/gammazero/deque v0.0.0-20190515085511-50f5fc498a27/go.mod h1:GeIq9qoE43YdGnDXURnmKTnGg15pQz4mYkXSTChbneI=
-github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622 h1:lxbhOGZ9pU3Kf8P6lFluUcE82yVZn2EqEf4+mWRNPV0=
-github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622/go.mod h1:D90+MBHVc9Sk1lJAbEVgws0eYEurY4mv2TDso3Nxh3w=
-github.com/gammazero/deque v0.0.0-20200124200322-7e84b94275b8 h1:9eg1l6iiw3aLaU3P8RRoosiYCRoWDg8HzPiy8xzWKgg=
-github.com/gammazero/deque v0.0.0-20200124200322-7e84b94275b8/go.mod h1:D90+MBHVc9Sk1lJAbEVgws0eYEurY4mv2TDso3Nxh3w=
-github.com/gammazero/deque v0.0.0-20200227231300-1e9af0e52b46 h1:iX4+rD9Fjdx8SkmSO/O5WAIX/j79ll3kuqv5VdYt9J8=
-github.com/gammazero/deque v0.0.0-20200227231300-1e9af0e52b46/go.mod h1:D90+MBHVc9Sk1lJAbEVgws0eYEurY4mv2TDso3Nxh3w=
+github.com/gammazero/deque v0.0.0-20200721202602-07291166fe33 h1:UG4wNrJX9xSKnm/Gck5yTbxnOhpNleuE4MQRdmcGySo=
+github.com/gammazero/deque v0.0.0-20200721202602-07291166fe33/go.mod h1:D90+MBHVc9Sk1lJAbEVgws0eYEurY4mv2TDso3Nxh3w=


### PR DESCRIPTION
- Be able to stop paused workerpool
- Handle concurrent calls to pause, to prevent deadlock
- If workers already paused, Pause waits for previous pauses to be canceled.