### PR TITLE
Create `SubmitRecover` to handle panic recovery in workerpool tasks if desired

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,32 +2,31 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
 
-    - name: Vet
-      run: go vet ./...
+      - name: Vet
+        run: go vet ./...
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -race -v ./... -coverprofile=coverage.txt -covermode=atomic
+      - name: Test
+        run: go test -race -v ./... -coverprofile=coverage.txt -covermode=atomic
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        files: coverage.txt
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          files: coverage.txt

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,6 @@ on:
   pull_request:
 
 jobs:
-
   golangci:
     name: lint
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _testmain.go
 *.prof
 
 coverage.out
+
+# IDE configuration
+.idea

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Andrew J. Gillis
+Copyright for portions of project gammazero/workerpool are held by
+Andrew J. Gillis, 2016 as part of project gammazero/workerpool. All
+other copyright for project highlight-run/workerpool are held by Highlight
+Inc, 2021-Continuing.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # workerpool
 
-[![GoDoc](https://pkg.go.dev/badge/github.com/gammazero/workerpool)](https://pkg.go.dev/github.com/gammazero/workerpool)
-[![Build Status](https://github.com/gammazero/workerpool/actions/workflows/go.yml/badge.svg)](https://github.com/gammazero/workerpool/actions/workflows/go.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/gammazero/workerpool)](https://goreportcard.com/report/github.com/gammazero/workerpool)
-[![codecov](https://codecov.io/gh/gammazero/workerpool/branch/master/graph/badge.svg)](https://codecov.io/gh/gammazero/workerpool)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/gammazero/workerpool/blob/master/LICENSE)
+[![GoDoc](https://pkg.go.dev/badge/github.com/highlight-run/workerpool)](https://pkg.go.dev/github.com/highlight-run/workerpool)
+[![Build Status](https://github.com/highlight-run/workerpool/actions/workflows/go.yml/badge.svg)](https://github.com/highlight-run/workerpool/actions/workflows/go.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/highlight-run/workerpool)](https://goreportcard.com/report/github.com/highlight-run/workerpool)
+[![codecov](https://codecov.io/gh/highlight-run/workerpool/branch/master/graph/badge.svg)](https://codecov.io/gh/highlight-run/workerpool)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/highlight-run/workerpool/blob/master/LICENSE)
 
 Concurrency limiting goroutine pool. Limits the concurrency of task execution, not the number of tasks queued. Never blocks submitting tasks, no matter how many tasks are queued.
 
@@ -14,18 +14,21 @@ This implementation builds on ideas from the following:
 - http://nesv.github.io/golang/2014/02/25/worker-queues-in-go.html
 
 ## Installation
-To install this package, you need to setup your Go workspace.  The simplest way to install the library is to run:
+
+To install this package, you need to setup your Go workspace. The simplest way to install the library is to run:
+
 ```
-$ go get github.com/gammazero/workerpool
+$ go get github.com/highlight-run/workerpool
 ```
 
 ## Example
+
 ```go
 package main
 
 import (
 	"fmt"
-	"github.com/gammazero/workerpool"
+	"github.com/highlight-run/workerpool"
 )
 
 func main() {
@@ -45,4 +48,4 @@ func main() {
 
 ## Usage Note
 
-There is no upper limit on the number of tasks queued, other than the limits of system resources.  If the number of inbound tasks is too many to even queue for pending processing, then the solution is outside the scope of workerpool.  If should be solved by distributing load over multiple systems, and/or storing input for pending processing in intermediate storage such as a file system, distributed message queue, etc.
+There is no upper limit on the number of tasks queued, other than the limits of system resources. If the number of inbound tasks is too many to even queue for pending processing, then the solution is outside the scope of workerpool. If should be solved by distributing load over multiple systems, and/or storing input for pending processing in intermediate storage such as a file system, distributed message queue, etc.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gammazero/workerpool
+module github.com/highlight-run/workerpool
 
 require (
 	github.com/gammazero/deque v0.1.0

--- a/pacer/pacer.go
+++ b/pacer/pacer.go
@@ -20,7 +20,7 @@ import "time"
 // To use Pacer, create a new Pacer giving the interval that must elapse
 // between the start of one task the start of the next task.  Then call Pace(),
 // passing your task function.  A new paced task function is returned that can
-// then be passed to WorkerPool's Submit() or SubmitWait(), or called as a go
+// then be passed to WorkerPool's submit() or SubmitWait(), or called as a go
 // routine.  Paced functions, that are run as goroutines, are also paced.  For
 // example:
 //
@@ -31,7 +31,7 @@ import "time"
 //     })
 //
 //     wp := workerpool.New(5)
-//     wp.Submit(pacedTask)
+//     wp.submit(pacedTask)
 //
 //     go pacedTask()
 //
@@ -58,7 +58,7 @@ func NewPacer(delay time.Duration) *Pacer {
 }
 
 // Pace wraps a function in a paced function.  The returned paced function can
-// then be submitted to the workerpool, using Submit or SubmitWait, and
+// then be submitted to the workerpool, using submit or SubmitWait, and
 // starting the tasks is paced according to the pacer's delay.
 func (p *Pacer) Pace(task func()) func() {
 	return func() {

--- a/pacer/pacer_test.go
+++ b/pacer/pacer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gammazero/workerpool"
+	"github.com/highlight-run/workerpool"
 )
 
 func TestPacedWorkers(t *testing.T) {
@@ -38,8 +38,8 @@ func TestPacedWorkers(t *testing.T) {
 
 	// Cause worker to be created, and available for reuse before next task.
 	for i := 0; i < 10; i++ {
-		wp.Submit(pacedTask)
-		wp.Submit(slowPacedTask)
+		wp.SubmitRecover(pacedTask)
+		wp.SubmitRecover(slowPacedTask)
 	}
 
 	time.Sleep(500 * time.Millisecond)

--- a/workerpool.go
+++ b/workerpool.go
@@ -93,13 +93,13 @@ func (p *WorkerPool) Stopped() bool {
 	return p.stopped
 }
 
-// Submit enqueues a function for a worker to execute.
+// submit enqueues a function for a worker to execute.
 //
 // Any external values needed by the task function must be captured in a
 // closure.  Any return values should be returned over a channel that is
 // captured in the task function closure.
 //
-// Submit will not block regardless of the number of tasks submitted.  Each
+// submit will not block regardless of the number of tasks submitted.  Each
 // task is immediately given to an available worker or to a newly started
 // worker.  If there are no available workers, and the maximum number of
 // workers are already created, then the task is put onto a waiting queue.
@@ -112,7 +112,7 @@ func (p *WorkerPool) Stopped() bool {
 // period until there are no more idle workers.  Since the time to start new
 // goroutines is not significant, there is no need to retain idle workers
 // indefinitely.
-func (p *WorkerPool) Submit(task func()) {
+func (p *WorkerPool) submit(task func()) {
 	if task != nil {
 		p.taskQueue <- task
 	}
@@ -175,7 +175,7 @@ func (p *WorkerPool) Pause(ctx context.Context) {
 	ready := new(sync.WaitGroup)
 	ready.Add(p.maxWorkers)
 	for i := 0; i < p.maxWorkers; i++ {
-		p.Submit(func() {
+		p.submit(func() {
 			ready.Done()
 			select {
 			case <-ctx.Done():

--- a/workerpool.go
+++ b/workerpool.go
@@ -131,7 +131,7 @@ func (p *WorkerPool) SubmitWait(task func()) {
 	<-doneChan
 }
 
-// SubmitRecover enqueues the given function and defers a panic recover func.
+// SubmitRecover enqueues the given function and defers a call to `p.panicHandler`.
 func (p *WorkerPool) SubmitRecover(task func()) {
 	if task != nil {
 		p.taskQueue <- func() {

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -20,7 +20,7 @@ func TestExample(t *testing.T) {
 	rspChan := make(chan string, len(requests))
 	for _, r := range requests {
 		r := r
-		wp.Submit(func() {
+		wp.submit(func() {
 			rspChan <- r
 		})
 	}
@@ -63,7 +63,7 @@ func TestMaxWorkers(t *testing.T) {
 
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < max; i++ {
-		wp.Submit(func() {
+		wp.submit(func() {
 			started <- struct{}{}
 			<-release
 		})
@@ -97,7 +97,7 @@ func TestReuseWorkers(t *testing.T) {
 
 	// Cause worker to be created, and available for reuse before next task.
 	for i := 0; i < 10; i++ {
-		wp.Submit(func() { <-release })
+		wp.submit(func() { <-release })
 		release <- struct{}{}
 		time.Sleep(time.Millisecond)
 	}
@@ -179,7 +179,7 @@ func TestStop(t *testing.T) {
 	release := make(chan struct{})
 	finished := make(chan struct{}, max)
 	for i := 0; i < max; i++ {
-		wp.Submit(func() {
+		wp.submit(func() {
 			<-release
 			finished <- struct{}{}
 		})
@@ -217,7 +217,7 @@ func TestStopWait(t *testing.T) {
 	release := make(chan struct{})
 	finished := make(chan struct{}, max)
 	for i := 0; i < max; i++ {
-		wp.Submit(func() {
+		wp.submit(func() {
 			<-release
 			finished <- struct{}{}
 		})
@@ -264,17 +264,17 @@ func TestSubmitWait(t *testing.T) {
 	defer wp.Stop()
 
 	// Check that these are noop.
-	wp.Submit(nil)
+	wp.submit(nil)
 	wp.SubmitWait(nil)
 
 	done1 := make(chan struct{})
-	wp.Submit(func() {
+	wp.submit(func() {
 		time.Sleep(100 * time.Millisecond)
 		close(done1)
 	})
 	select {
 	case <-done1:
-		t.Fatal("Submit did not return immediately")
+		t.Fatal("submit did not return immediately")
 	default:
 	}
 
@@ -311,7 +311,7 @@ func TestOverflow(t *testing.T) {
 
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < 64; i++ {
-		wp.Submit(func() { <-releaseChan })
+		wp.submit(func() { <-releaseChan })
 	}
 
 	// Start a goroutine to free the workers after calling stop.  This way
@@ -344,7 +344,7 @@ func TestStopRace(t *testing.T) {
 
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < max; i++ {
-		wp.Submit(func() {
+		wp.submit(func() {
 			started.Done()
 			<-workRelChan
 		})
@@ -396,10 +396,10 @@ func TestWaitingQueueSizeRace(t *testing.T) {
 	for g := 0; g < goroutines; g++ {
 		go func() {
 			max := 0
-			// Submit 100 tasks, checking waiting queue size each time.  Report
+			// submit 100 tasks, checking waiting queue size each time.  Report
 			// the maximum queue size seen.
 			for i := 0; i < tasks; i++ {
-				wp.Submit(func() {
+				wp.submit(func() {
 					time.Sleep(time.Microsecond)
 				})
 				waiting := wp.WaitingQueueSize()
@@ -436,7 +436,7 @@ func TestPause(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	ran := make(chan struct{})
-	wp.Submit(func() {
+	wp.submit(func() {
 		time.Sleep(time.Millisecond)
 		close(ran)
 	})
@@ -451,7 +451,7 @@ func TestPause(t *testing.T) {
 	}
 
 	ran = make(chan struct{})
-	wp.Submit(func() {
+	wp.submit(func() {
 		close(ran)
 	})
 
@@ -548,7 +548,7 @@ func TestPause(t *testing.T) {
 	go wp.Pause(ctx2)
 
 	ran = make(chan struct{})
-	wp.Submit(func() {
+	wp.submit(func() {
 		close(ran)
 	})
 
@@ -600,7 +600,7 @@ func TestWorkerLeak(t *testing.T) {
 
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < workerCount; i++ {
-		wp.Submit(func() {
+		wp.submit(func() {
 			time.Sleep(time.Millisecond)
 		})
 	}
@@ -660,7 +660,7 @@ func BenchmarkEnqueue(b *testing.B) {
 
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < b.N; i++ {
-		wp.Submit(func() { <-releaseChan })
+		wp.submit(func() { <-releaseChan })
 	}
 	close(releaseChan)
 }
@@ -675,7 +675,7 @@ func BenchmarkEnqueue2(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		releaseChan := make(chan struct{})
 		for i := 0; i < 64; i++ {
-			wp.Submit(func() { <-releaseChan })
+			wp.submit(func() { <-releaseChan })
 		}
 		close(releaseChan)
 	}
@@ -716,7 +716,7 @@ func benchmarkExecWorkers(n int, b *testing.B) {
 	// Start workers, and have them all wait on a channel before completing.
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < n; j++ {
-			wp.Submit(func() {
+			wp.submit(func() {
 				//time.Sleep(100 * time.Microsecond)
 				allDone.Done()
 			})

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -290,6 +290,18 @@ func TestSubmitWait(t *testing.T) {
 	}
 }
 
+func TestSubmitRecover(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	wp := New(1)
+	defer wp.Stop()
+
+	// if panic isn't recovered, test will fail
+	wp.SubmitRecover(func() {
+		panic("panic test")
+	})
+}
+
 func TestOverflow(t *testing.T) {
 	defer goleak.VerifyNone(t)
 


### PR DESCRIPTION
allows user to overwrite the panic handler function with `workerpool.SetPanicHandler(func())`