### PR TITLE
Add blocking submission of tasks until worker becomes available

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ This implementation builds on ideas from the following:
 - http://nesv.github.io/golang/2014/02/25/worker-queues-in-go.html
 
 ## Installation
-To install this package, you need to setup your Go workspace.  The simplest way to install the library is to run:
+
+To install this package, you need to setup your Go workspace. The simplest way to install the library is to run:
+
 ```
 $ go get github.com/gammazero/workerpool
 ```
 
 ## Example
+
 ```go
 package main
 
@@ -45,4 +48,11 @@ func main() {
 
 ## Usage Note
 
-There is no upper limit on the number of tasks queued, other than the limits of system resources.  If the number of inbound tasks is too many to even queue for pending processing, then the solution is outside the scope of workerpool.  If should be solved by distributing load over multiple systems, and/or storing input for pending processing in intermediate storage such as a file system, distributed message queue, etc.
+### Submit To Queue
+
+There is no upper limit on the number of tasks queued, other than the limits of system resources. If the number of inbound tasks is too many to even queue for pending processing, then the solution is outside the scope of workerpool. If should be solved by distributing load over multiple systems, and/or storing input for pending processing in intermediate storage such as a file system, distributed message queue, etc.
+
+### Submit To Worker
+
+When using SubmitWaitWorker the function call is blocked if there are
+no workers available. This can be useful for limiting the size of the task queue by blocking the incoming tasks.

--- a/README.md
+++ b/README.md
@@ -54,5 +54,4 @@ There is no upper limit on the number of tasks queued, other than the limits of 
 
 ### Submit To Worker
 
-When using SubmitWaitWorker the function call is blocked if there are
-no workers available. This can be useful for limiting the size of the task queue by blocking the incoming tasks.
+When using SubmitWaitWorker the function call is blocked if there are no workers available. This can be useful for limiting the size of the task queue by blocking the incoming tasks.

--- a/doc.go
+++ b/doc.go
@@ -6,23 +6,26 @@ executed by the workers.  This is useful when performing tasks that require
 sufficient resources (CPU, memory, etc.), and running too many tasks at the
 same time would exhaust resources.
 
-Non-blocking task submission
+Non-blocking and blocking task submission
 
-A task is a function submitted to the worker pool for execution.  Submitting
-tasks to this worker pool will not block, regardless of the number of tasks.
-Incoming tasks are immediately dispatched to an available
-worker.  If no worker is immediately available, or there are already tasks
-waiting for an available worker, then the task is put on a waiting queue to
-wait for an available worker.
+A task is a function submitted to the worker pool for execution. There are
+different ways of submitting a task, non-blocking and blocking. A non-blocking
+task submission will not block, regardless of the number of tasks. Incoming tasks
+are immediately dispatched to an available worker.  If no worker is immediately
+available, or there are already tasks waiting for an available worker, then the
+task is put on a waiting queue to wait for an available worker. However, blocking task
+submission will block the submission until a worker becomes available and starts
+executing the task.
 
-The intent of the worker pool is to limit the concurrency of task execution,
-not limit the number of tasks queued to be executed.  Therefore, this unbounded
-input of tasks is acceptable as the tasks cannot be discarded.  If the number
+The main intent of the worker pool is to limit the concurrency of task execution,
+not limit the number of tasks queued to be executed. Therefore, this unbounded
+input of tasks is acceptable as the tasks cannot be discarded. If the number
 of inbound tasks is too many to even queue for pending processing, then the
 solution is outside the scope of workerpool, and should be solved by
 distributing load over multiple systems, and/or storing input for pending
 processing in intermediate storage such as a database, file system, distributed
-message queue, etc.
+message queue, etc. However, with the blocking task submissions one can regulate
+the number of incoming tasks to the worker pool if desired.
 
 Dispatcher
 
@@ -47,13 +50,12 @@ than tasks that use Y Mb of memory.
 
 Waiting queue vs goroutines
 
-When there are no available workers to handle incoming tasks, the tasks are put
-on a waiting queue, in this implementation.  In implementations mentioned in
-the credits below, these tasks were passed to goroutines.  Using a queue is
-faster and has less memory overhead than creating a separate goroutine for each
-waiting task, allowing a much higher number of waiting tasks.  Also, using a
-waiting queue ensures that tasks are given to workers in the order the tasks
-were received.
+When submitting in a non-blocking way and there are no available workers to handle
+incoming tasks, the tasks are put on a waiting queue, in this implementation.
+In implementations mentioned in the credits below, these tasks were passed to goroutines.
+Using a queue is faster and has less memory overhead than creating a separate goroutine
+for each waiting task, allowing a much higher number of waiting tasks.  Also, using a
+waiting queue ensures that tasks are given to workers in the order the tasks were received.
 
 Credits
 

--- a/workerpool.go
+++ b/workerpool.go
@@ -112,13 +112,29 @@ func (p *WorkerPool) Submit(task func()) {
 
 // SubmitWait enqueues the given function and waits for it to be executed.
 func (p *WorkerPool) SubmitWait(task func()) {
+	p.submitWait(task, false)
+}
+
+// SubmitWaitWorker enqueues the given function and waits for it to be taken by a worker.
+func (p *WorkerPool) SubmitWaitWorker(task func()) {
+	p.submitWait(task, true)
+}
+
+func (p *WorkerPool) submitWait(task func(), waitForWorker bool) {
 	if task == nil {
 		return
 	}
 	doneChan := make(chan struct{})
 	p.taskQueue <- func() {
-		task()
-		close(doneChan)
+
+		if waitForWorker {
+			close(doneChan)
+			task()
+		} else {
+			task()
+			close(doneChan)
+		}
+
 	}
 	<-doneChan
 }


### PR DESCRIPTION
By creating a blocking submission alternative in worker pool the size of task queue can be regulated/controlled. This could be useful when you want to limit the size of task queue, e.g. to the number of workers.

This PR includes small changes similar to SubmitWait where the only difference is to close the "done" channel before executing the actual task from the worker, like so:

```
if waitForWorker {
    close(doneChan)
    task()
} else {
    task()
    close(doneChan)
}
```