### PR TITLE
perf: unify startWorker and worker to spawn less goroutines

### DIFF
--- a/workerpool.go
+++ b/workerpool.go
@@ -233,14 +233,11 @@ Loop:
 
 // worker executes tasks and stops when it receives a nil task.
 func worker(task func(), workerQueue chan func(), wg *sync.WaitGroup) {
-	task()
-	for task := range workerQueue {
-		if task == nil {
-			wg.Done()
-			return
-		}
+	for task != nil {
 		task()
+		task = <-workerQueue
 	}
+	wg.Done()
 }
 
 // stop tells the dispatcher to exit, and whether or not to complete queued

--- a/workerpool.go
+++ b/workerpool.go
@@ -194,7 +194,7 @@ Loop:
 				// Create a new worker, if not at max.
 				if workerCount < p.maxWorkers {
 					wg.Add(1)
-					go startWorker(task, p.workerQueue, &wg)
+					go worker(task, p.workerQueue, &wg)
 					workerCount++
 				} else {
 					// Enqueue task to be executed by next available worker.
@@ -231,14 +231,9 @@ Loop:
 	timeout.Stop()
 }
 
-// startWorker runs initial task, then starts a worker waiting for more.
-func startWorker(task func(), workerQueue chan func(), wg *sync.WaitGroup) {
-	task()
-	go worker(workerQueue, wg)
-}
-
 // worker executes tasks and stops when it receives a nil task.
-func worker(workerQueue chan func(), wg *sync.WaitGroup) {
+func worker(task func(), workerQueue chan func(), wg *sync.WaitGroup) {
+	task()
 	for task := range workerQueue {
 		if task == nil {
 			wg.Done()


### PR DESCRIPTION
This PR is more like a question, more than a fix, as I think `worker` and `startWorker` are in split for a reason, which I just probably don't get. Can you pls explain it? I couldn't find the answer in git history and out of curiosity.  

If there is no reason for that, then this PR should decrease the load on the runtime by spawning fewer routines in general and one less per worker in particular. Thanks for the great library anyway.