### PR TITLE
Idle timeout can be disabled

### DIFF
--- a/options.go
+++ b/options.go
@@ -17,7 +17,7 @@ type Option func(*config)
 
 // WithIdleTimeout configures the the amount of time that the worker pool must
 // be idle before a worker is automatically stopped. If zero or unset the value
-// defaults to DefaultIdleTimeout.
+// defaults to DefaultIdleTimeout. A negative value disables the idle timeout.
 func WithIdleTimeout(timeout time.Duration) Option {
 	return func(c *config) {
 		if timeout != 0 {

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -152,6 +152,31 @@ func TestWorkerTimeout(t *testing.T) {
 	})
 }
 
+func TestWorkerNoTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		wp := New(max, WithIdleTimeout(-1))
+		defer wp.Stop()
+
+		// Start workers, and have them all wait on ctx before completing.
+		ctx, cancel := context.WithCancel(context.Background())
+		wp.Pause(ctx)
+		cancel()
+
+		// Check that a worker timed out.
+		time.Sleep(time.Hour)
+		synctest.Wait()
+		if countReady(wp) != max {
+			t.Fatal("no workers should have timed out")
+		}
+		// Check again.
+		time.Sleep(time.Hour)
+		synctest.Wait()
+		if countReady(wp) != max {
+			t.Fatal("no workers should have timed out")
+		}
+	})
+}
+
 func TestStop(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		wp := New(max)


### PR DESCRIPTION
Configuring the idle timeout to a negative, using the `WithIdleTimeout` option, disables the idle timeout.